### PR TITLE
v0.3.1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
     "isbot",
     "lefthook",
     "openshare",
+    "opfs",
     "privkey",
     "qrcode",
     "VITE",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openshare/web",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "react-router dev",

--- a/apps/web/src/pages/Receiver.tsx
+++ b/apps/web/src/pages/Receiver.tsx
@@ -105,14 +105,16 @@ export default function Receiver() {
           }
           file.receiveSize += event.data.byteLength;
 
-          setReceiveFiles((prev) =>
-            prev.map((receiveFile) => {
-              if (receiveFile.isPending) {
-                receiveFile.receiveSize = file.receiveSize;
-              }
-              return receiveFile;
-            }),
-          );
+          if (file.receiveSize % (Math.floor(file.size / event.data.byteLength / 100) * event.data.byteLength) === 0) {
+            setReceiveFiles((prev) =>
+              prev.map((receiveFile) => {
+                if (receiveFile.isPending) {
+                  receiveFile.receiveSize = file.receiveSize;
+                }
+                return receiveFile;
+              }),
+            );
+          }
 
           // console.log(file);
           if (file.size === file.receiveSize) {
@@ -122,7 +124,9 @@ export default function Receiver() {
             }
             setReceiveFiles((files) =>
               files.map((rFile) =>
-                rFile.name === file.name ? { ...rFile, isPending: false, end: new Date() } : rFile,
+                rFile.name === file.name
+                  ? { ...rFile, isPending: false, end: new Date(), receiveSize: file.receiveSize }
+                  : rFile,
               ),
             );
           }

--- a/apps/web/src/pages/Sender.tsx
+++ b/apps/web/src/pages/Sender.tsx
@@ -166,7 +166,6 @@ export default function Sender() {
     return cleanUp;
   }, []);
 
-  const maxTransferSize = 1000 ** 3;
   const maxFiles = 5;
 
   return (
@@ -174,14 +173,12 @@ export default function Sender() {
       <Flex gap={{ base: "xl", md: "sm" }} wrap={{ base: "nowrap", md: "wrap" }}>
         <Dropzone
           multiple
-          maxSize={maxTransferSize}
           maxFiles={5}
           onDrop={(acceptedFiles) => {
             // console.log("accepted files", acceptedFiles, "rejected files", fileRejections);
 
             const preNumOfFiles = files.length + acceptedFiles.length;
-            const preSize = files.reduce((a, c) => a + c.file.size, 0) + acceptedFiles.reduce((a, c) => a + c.size, 0);
-            if (preNumOfFiles <= maxFiles && preSize <= maxTransferSize) {
+            if (preNumOfFiles <= maxFiles) {
               // console.log(preNumOfFiles, preSize);
               setFiles((prev) => [...prev, ...acceptedFiles.map((file) => ({ file }))]);
             } else {
@@ -196,9 +193,6 @@ export default function Sender() {
         >
           <Text fontSize="xl">
             ドラッグ&ドロップかクリックしてファイルを追加
-            <br />
-            最大
-            <FormatByte value={maxTransferSize} />
             <br />
             {maxFiles}ファイルまで
           </Text>

--- a/apps/web/src/root.tsx
+++ b/apps/web/src/root.tsx
@@ -1,9 +1,10 @@
 import { ColorModeScript, UIProvider, defaultConfig } from "@yamada-ui/react";
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect } from "react";
 import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "react-router";
 import type { Route } from "./+types/root.ts";
 
 import LoadingScreen from "@/components/LoadingScreen";
+import { getReceiveTempDirHandle } from "./utils/opfs.ts";
 
 export const links: Route.LinksFunction = () => [
   {
@@ -14,6 +15,18 @@ export const links: Route.LinksFunction = () => [
 ];
 
 export function Layout({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    (async () => {
+      const receiveTempDir = await getReceiveTempDirHandle();
+      let deletedCount = 0;
+      for await (const fileName of receiveTempDir.keys()) {
+        receiveTempDir.removeEntry(fileName);
+        deletedCount++;
+      }
+      console.log(deletedCount ? `過去に受信した${deletedCount}個のファイルを削除` : "削除ファイルなし");
+    })();
+  }, []);
+
   return (
     <html lang="ja" suppressHydrationWarning>
       <head>

--- a/apps/web/src/utils/opfs.ts
+++ b/apps/web/src/utils/opfs.ts
@@ -1,0 +1,9 @@
+export async function getReceiveTempDirHandle() {
+  const root = await navigator.storage.getDirectory();
+  return await root.getDirectoryHandle("receive_temp", { create: true });
+}
+
+export async function getReceiveFileHandle(name: string, options?: FileSystemGetFileOptions) {
+  const receiveTempDir = await getReceiveTempDirHandle();
+  return await receiveTempDir.getFileHandle(name, options);
+}

--- a/apps/web/src/utils/webRTC.ts
+++ b/apps/web/src/utils/webRTC.ts
@@ -144,7 +144,7 @@ export class RTCSession {
         const chunk = file.file.slice(offset, offset + this.maxChunkSize);
         offset += chunk.size;
         dataChannel.send(await chunk.arrayBuffer());
-        if (offset % (this.maxChunkSize * 10) === 0) {
+        if (offset % (Math.floor(file.file.size / this.maxChunkSize / 100) * this.maxChunkSize) === 0) {
           updateProgress();
         }
       }

--- a/apps/web/src/utils/webRTC.ts
+++ b/apps/web/src/utils/webRTC.ts
@@ -129,9 +129,8 @@ export class RTCSession {
       );
     }
 
-    const buffer = await file.file.arrayBuffer();
-    const send = () => {
-      while (offset < buffer.byteLength) {
+    const send = async () => {
+      while (offset < file.file.size) {
         if (dataChannel.bufferedAmount > dataChannel.bufferedAmountLowThreshold) {
           // console.log("bufferedAmount", dataChannel.bufferedAmount);
           if (!dataChannel.onbufferedamountlow) {
@@ -142,9 +141,9 @@ export class RTCSession {
           }
           return;
         }
-        const chunk = buffer.slice(offset, offset + this.maxChunkSize);
-        offset += chunk.byteLength;
-        dataChannel.send(chunk);
+        const chunk = file.file.slice(offset, offset + this.maxChunkSize);
+        offset += chunk.size;
+        dataChannel.send(await chunk.arrayBuffer());
         if (offset % (this.maxChunkSize * 10) === 0) {
           updateProgress();
         }
@@ -164,7 +163,7 @@ export class RTCSession {
       );
       resolve();
     };
-    send();
+    await send();
   }
 
   sendFileInfo(file: File, dataChannel: RTCDataChannel) {

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -3,7 +3,7 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
## 概要
OPFS（Origin Private File System）を使って、ファイル送信・受信のメモリを削減した
プログレスバーの更新頻度を最適化して、送受信パフォーマンスも向上

## 主な変更点
### 送信側

ファイル送信時、メモリに依存せずチャンクごとに読み込みするようにリファクタ
それに伴い送信サイズ1GB制限を撤廃
### 受信側

OPFS対応ブラウザ限定で、受信ファイルを直接ストリームで保存
受信サイズも無制限に
過去に受信してopfs内に保存されたファイルはを自動削除する仕組みを追加
### UI/UX

プログレスバーの更新頻度をファイルサイズの1%ごとに削減して、描画負荷を軽減
ファイルダウンロード時もOPFS対応ならネイティブ保存ダイアログを利用